### PR TITLE
Cancel active PR validation runs on pushing update to PR

### DIFF
--- a/.github/workflows/PR-validation.yml
+++ b/.github/workflows/PR-validation.yml
@@ -4,6 +4,9 @@ on:
     types: [synchronize, opened, reopened, edited]
     branches:
       - main
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 jobs:
   pipeline-seq-retrieval-container-image-build:
     name: pipeline/seq_retrieval container-image build

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # AGR PAVI
 AGR's Proteins Annotations and Variants Inspector
 
+## Architecture
+Section TODO.
+
 ## Acknowledgements
 Just as most modern software, PAVI heavily relies on third-party tools and libraries for much of its core functionality.
 We specifically acknowledge the creators and developers of the following third-party tools and libraries:


### PR DESCRIPTION
This update cancels active PR validation runs within a single PR when an update is pushed to that PR. PR validation running in other PRs (with another number) will remain active.