### PR TITLE
Automatic PR-validation dependency lock updates: move commit after merge

### DIFF
--- a/.github/workflows/PR-validation.yml
+++ b/.github/workflows/PR-validation.yml
@@ -969,35 +969,19 @@ jobs:
           push: false
           tags: agr_pavi/webui:latest
           outputs: type=docker,dest=/tmp/pavi_webui_docker_image.tar
-  commit-deps-lock-updates:
-    #TODO: Moving the commit from before to after merge to prevent need for repetitive forced reruns of PR-validation.
-    #       * Convert this job into job that tars up all updated dependency files and uploads them as a single artifact.
-    #       * The new artifact should then be downloaded, unpacked and committed in the main-build-and-deploy workflow.
-    #       * PR validation should get an additional job that reports in the open PR if dependency files have been updated,
-    #         with a link to the updated files or summary report to enable inspection before merge (download and report git diff?).
+  stage-deps-lock-updates:
     runs-on: ubuntu-22.04
-    #Only commit updated lock files on successfull validation (to prevent PR cluttering)
+    # Always stage updated lock files, even on failure,
+    #  to highlight dependency changes which could be the cause of the failure.
     needs:
       - shared-aws-infra-update-dependency-lock-files
       - shared-aws-infra-package-build
       - api-aws-infra-update-dependency-lock-files
-      - api-aws-infra-code-checks
       - pipeline-aws-infra-update-dependency-lock-files
-      - pipeline-aws-infra-code-checks
       - webui-aws-infra-update-dependency-lock-files
-      - webui-aws-infra-code-checks
       - api-update-dependency-lock-files
-      - api-container-integration-testing
-      - api-unit-integration-testing
-      - api-code-checks
       - pipeline-seq-retrieval-update-dependency-lock-files
-      - pipeline-seq-retrieval-code-checks
-      - pipeline-workflow-integration-testing
       - webui-update-dependency-lock-files
-      - webui-code-checks
-      - webui-container-image-build
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1068,31 +1052,34 @@ jobs:
         with:
           name: webui_deps_lock
           path: webui
-      # Independent shared_aws_infra lock files commit required to pin hash representing the package
-      # to be included in depending aws_infra components' lock files.
-      - name: commit shared_aws_infra dependency lock file changes
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: Auto-updated pavi_shared_aws_infra deps lock files
-          file_pattern: 'shared_aws_infra/requirements.txt shared_aws_infra/tests/requirements.txt'
-          disable_globbing: true
-      # Build pavi_shared_aws_infra package (to ensure hash includes latest commit date)
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - name: Build and install the pavi_shared_aws_infra package
-        working-directory: ./shared_aws_infra
+      - name: Bundle all deps lock files
         run: |
-          make clean build install
-      - name: Update pavi_shared_aws_infra dependencies
-        run: |
-          make -C api/aws_infra/ pip-tools update-deps-lock-shared-aws-infra-only update-test-deps-lock-shared-aws-infra-only
-          make -C pipeline/aws_infra/ pip-tools update-deps-lock-shared-aws-infra-only update-test-deps-lock-shared-aws-infra-only
-          make -C webui/aws_infra/ pip-tools update-deps-lock-shared-aws-infra-only update-test-deps-lock-shared-aws-infra-only
-      - name: commit remaining dependency lock file changes
-        uses: stefanzweifel/git-auto-commit-action@v5
+          find . -regex '.*/\(requirements\.txt\|package-lock\.json\)' -print | \
+          tar -czv -f deps-lock-files.tar.gz --files-from -
+      # Upload the deps-lock-files bundle as workflow artifact (to be downloaded on PR merge)
+      - name: Upload deps-lock-files bundle as artifact
+        uses: actions/upload-artifact@v4
         with:
-          commit_message: Auto-updated deps lock files
-          file_pattern: '*requirements.txt *package-lock.json'
-          disable_globbing: true
+          name: deps_lock_files_bundle
+          path: deps-lock-files.tar.gz
+      # Share diff of changes in PR
+      - name: calculate and store diff of changes
+        id: step_one
+        run: |
+          {
+            echo 'GIT_DIFF_VIEW<<EOF'
+            git diff --
+            echo EOF
+          } >> "$GITHUB_ENV"
+      - name: Post PR comment with diff view
+        env:
+          GH_TOKEN: ${{ github.token }}
+          pr-comment: |
+            The validation workflow automatically applied the following dependency lock file updates.
+            Note that hashes for the pavi_share_aws_infra package will change after merge, as they are commit-date dependent.
+            ```diff
+            (${{ env.GIT_DIFF_VIEW }})
+            ```
+            A bundle with all dependency lock files is available as artifact [here](${{ github.repository.html_url }}/${{ github.run_id }}) as `deps_lock_files_bundle`.
+        run: |
+          gh pr comment ${{ github.event.pull_request._links.comments }} --body "${{ env.pr-comment }}"

--- a/.github/workflows/PR-validation.yml
+++ b/.github/workflows/PR-validation.yml
@@ -1080,4 +1080,4 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh pr comment ${{ github.event.pull_request._links.comments }} --body-file git-diff-message.md
+          gh pr comment ${{ github.event.pull_request._links.comments.href }} --body-file git-diff-message.md

--- a/.github/workflows/PR-validation.yml
+++ b/.github/workflows/PR-validation.yml
@@ -1069,7 +1069,7 @@ jobs:
       - name: calculate diff for each individual file
         run: |
           mkdir diff-files/
-          cat diff-files.txt | xargs -I {} bash ci-scripts/create-git-diff-markdown.sh {} diff-files/
+          cat diff-files.txt | xargs -I {} bash ci-scripts/create-git-diff-markdown.sh {} diff-files
       - name: Generate and store change message
         run: |
           {

--- a/.github/workflows/PR-validation.yml
+++ b/.github/workflows/PR-validation.yml
@@ -970,12 +970,12 @@ jobs:
           tags: agr_pavi/webui:latest
           outputs: type=docker,dest=/tmp/pavi_webui_docker_image.tar
   stage-deps-lock-updates:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-deps-lock-updates') }}
     runs-on: ubuntu-22.04
     # Always stage updated lock files, even on failure,
     #  to highlight dependency changes which could be the cause of the failure.
     needs:
       - shared-aws-infra-update-dependency-lock-files
-      - shared-aws-infra-package-build
       - api-aws-infra-update-dependency-lock-files
       - pipeline-aws-infra-update-dependency-lock-files
       - webui-aws-infra-update-dependency-lock-files

--- a/.github/workflows/PR-validation.yml
+++ b/.github/workflows/PR-validation.yml
@@ -1063,19 +1063,19 @@ jobs:
           name: deps_lock_files_bundle
           path: deps-lock-files.tar.gz
       # Share diff of changes in PR
-      - name: calculate diff of changes and store as file
+      - name: Generate list of files that were updated
         run: |
-            git diff -- > git-diff.out
+            git diff --name-only -- > diff-files.txt
+      - name: calculate diff for each individual file
+        run: |
+          mkdir diff-files/
+          cat diff-files.txt | xargs -I {} bash ci-scripts/create-git-diff.sh {} diff-files/
       - name: Generate and store change message
         run: |
           {
             echo 'The validation workflow automatically applied the below dependency lock file updates.'
-            echo '<details>'
-            echo '<summary>Click to show diff</summary>'
-            echo '```diff'
-            cat git-diff.out
-            echo '```'
-            echo '</details>'
+            cat diff-files.txt | xargs -I {} cat diff-files/{}.md
+            echo ''
             echo 'Note that hashes for the pavi_share_aws_infra package can change after merge, as the package hash is commit-date dependent.'
             echo 'A bundle with all dependency lock files is available [here](${{ github.event.repository.html_url }}/${{ github.run_id }}) as artifact called `deps_lock_files_bundle`.'
           } > git-diff-message.md

--- a/.github/workflows/PR-validation.yml
+++ b/.github/workflows/PR-validation.yml
@@ -1080,4 +1080,4 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh pr comment ${{ github.event.pull_request._links.comments.href }} --body-file git-diff-message.md
+          gh pr comment ${{ github.event.pull_request._links.html.href }} --body-file git-diff-message.md

--- a/.github/workflows/PR-validation.yml
+++ b/.github/workflows/PR-validation.yml
@@ -1063,23 +1063,21 @@ jobs:
           name: deps_lock_files_bundle
           path: deps-lock-files.tar.gz
       # Share diff of changes in PR
-      - name: calculate and store diff of changes
-        id: step_one
+      - name: calculate diff of changes and store as file
+        run: |
+            git diff -- > git-diff.out
+      - name: Generate and store change message
         run: |
           {
-            echo 'GIT_DIFF_VIEW<<EOF'
-            git diff --
-            echo EOF
-          } >> "$GITHUB_ENV"
-      - name: Post PR comment with diff view
+            echo 'The validation workflow automatically applied the following dependency lock file updates.'
+            echo 'Note that hashes for the pavi_share_aws_infra package will change after merge, as they are commit-date dependent.'
+            echo '```diff'
+            cat git-diff.out
+            echo '```'
+            echo 'A bundle with all dependency lock files is available as artifact [here](${{ github.repository.html_url }}/${{ github.run_id }}) as `deps_lock_files_bundle`.'
+          } > git-diff-message.md
+      - name: Post PR comment with change message
         env:
           GH_TOKEN: ${{ github.token }}
-          pr-comment: |
-            The validation workflow automatically applied the following dependency lock file updates.
-            Note that hashes for the pavi_share_aws_infra package will change after merge, as they are commit-date dependent.
-            ```diff
-            (${{ env.GIT_DIFF_VIEW }})
-            ```
-            A bundle with all dependency lock files is available as artifact [here](${{ github.repository.html_url }}/${{ github.run_id }}) as `deps_lock_files_bundle`.
         run: |
-          gh pr comment ${{ github.event.pull_request._links.comments }} --body "${{ env.pr-comment }}"
+          gh pr comment ${{ github.event.pull_request._links.comments }} --body-file git-diff-message.md

--- a/.github/workflows/PR-validation.yml
+++ b/.github/workflows/PR-validation.yml
@@ -1077,7 +1077,7 @@ jobs:
             cat diff-files.txt | xargs -I {} cat diff-files/{}.md
             echo ''
             echo 'Note that hashes for the pavi_share_aws_infra package can change after merge, as the package hash is commit-date dependent.'
-            echo 'A bundle with all dependency lock files is available [here](${{ github.event.repository.html_url }}/${{ github.run_id }}) as artifact called `deps_lock_files_bundle`.'
+            echo 'A bundle with all dependency lock files is available [here](${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}) as artifact called `deps_lock_files_bundle`.'
           } > git-diff-message.md
       - name: Post PR comment with change message
         env:

--- a/.github/workflows/PR-validation.yml
+++ b/.github/workflows/PR-validation.yml
@@ -1069,12 +1069,15 @@ jobs:
       - name: Generate and store change message
         run: |
           {
-            echo 'The validation workflow automatically applied the following dependency lock file updates.'
-            echo 'Note that hashes for the pavi_share_aws_infra package will change after merge, as they are commit-date dependent.'
+            echo 'The validation workflow automatically applied the below dependency lock file updates.'
+            echo '<details>'
+            echo '<summary>Click to show diff</summary>'
             echo '```diff'
             cat git-diff.out
             echo '```'
-            echo 'A bundle with all dependency lock files is available as artifact [here](${{ github.event.repository.html_url }}/${{ github.run_id }}) as `deps_lock_files_bundle`.'
+            echo '</details>'
+            echo 'Note that hashes for the pavi_share_aws_infra package can change after merge, as the package hash is commit-date dependent.'
+            echo 'A bundle with all dependency lock files is available [here](${{ github.event.repository.html_url }}/${{ github.run_id }}) as artifact called `deps_lock_files_bundle`.'
           } > git-diff-message.md
       - name: Post PR comment with change message
         env:

--- a/.github/workflows/PR-validation.yml
+++ b/.github/workflows/PR-validation.yml
@@ -1074,7 +1074,7 @@ jobs:
             echo '```diff'
             cat git-diff.out
             echo '```'
-            echo 'A bundle with all dependency lock files is available as artifact [here](${{ github.repository.html_url }}/${{ github.run_id }}) as `deps_lock_files_bundle`.'
+            echo 'A bundle with all dependency lock files is available as artifact [here](${{ github.event.repository.html_url }}/${{ github.run_id }}) as `deps_lock_files_bundle`.'
           } > git-diff-message.md
       - name: Post PR comment with change message
         env:

--- a/.github/workflows/PR-validation.yml
+++ b/.github/workflows/PR-validation.yml
@@ -1069,7 +1069,7 @@ jobs:
       - name: calculate diff for each individual file
         run: |
           mkdir diff-files/
-          cat diff-files.txt | xargs -I {} bash ci-scripts/create-git-diff.sh {} diff-files/
+          cat diff-files.txt | xargs -I {} bash ci-scripts/create-git-diff-markdown.sh {} diff-files/
       - name: Generate and store change message
         run: |
           {

--- a/.github/workflows/PR-validation.yml
+++ b/.github/workflows/PR-validation.yml
@@ -1064,13 +1064,21 @@ jobs:
           path: deps-lock-files.tar.gz
       # Share diff of changes in PR
       - name: Generate list of files that were updated
+        id: diff-files
         run: |
             git diff --name-only -- > diff-files.txt
-      - name: calculate diff for each individual file
+            {
+              echo 'content<<EOF'
+              cat diff-files.txt
+              echo EOF
+            } >> "$GITHUB_OUTPUT"
+      - name: Calculate diff for each individual file
+        if: ${{ steps.diff-files.outputs.content }}
         run: |
           mkdir diff-files/
           cat diff-files.txt | xargs -I {} bash ci-scripts/create-git-diff-markdown.sh {} diff-files
       - name: Generate and store change message
+        if: ${{ steps.diff-files.outputs.content }}
         run: |
           {
             echo 'The validation workflow automatically applied the below dependency lock file updates.'
@@ -1079,8 +1087,22 @@ jobs:
             echo 'Note that hashes for the pavi_share_aws_infra package can change after merge, as the package hash is commit-date dependent.'
             echo 'A bundle with all dependency lock files is available [here](${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}) as artifact called `deps_lock_files_bundle`.'
           } > git-diff-message.md
+      - name: Generate and store no-change message
+        if: ${{ !steps.diff-files.outputs.content }}
+        run: |
+          {
+            echo 'Automatic dependency lock file updates enabled, but no updates found. No dependency updates will be made when merging this PR.'
       - name: Post PR comment with change message
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh pr comment ${{ github.event.pull_request._links.html.href }} --body-file git-diff-message.md
+  report-no-deps-lock-updates-label:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'no-deps-lock-updates') }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Post PR comment with notification no updates will be made
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr comment ${{ github.event.pull_request._links.html.href }} --body '`no-deps-lock-updates` label detected, so automatic dependency lock file updates are disabled. No dependency updates will be made when merging this PR.'

--- a/.github/workflows/main-build-and-deploy.yml
+++ b/.github/workflows/main-build-and-deploy.yml
@@ -31,10 +31,22 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: create token for committing and pushing as agr-github-actions app
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.GH_ACTIONS_APP_ID }}
+          private-key: ${{ secrets.GH_ACTIONS_APP_PRIVATE_KEY }}
+      - name: Get GitHub App User ID
+        id: app-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.base_ref }}
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
       - name: Download updated dependencies lock files bundle
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-deps-lock-updates') }}
         uses: dawidd6/action-download-artifact@v6
@@ -57,7 +69,9 @@ jobs:
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-deps-lock-updates') }}
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: Auto-updated pavi_shared_aws_infra deps lock files
+          commit_user_name: ${{ steps.app-token.outputs.app-slug }}[bot]
+          commit_user_email: ${{ steps.app-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>
+          commit_message: Auto-updated pavi_shared_aws_infra deps lock files [skip actions]
           file_pattern: 'shared_aws_infra/requirements.txt shared_aws_infra/tests/requirements.txt'
           disable_globbing: true
       # Build pavi_shared_aws_infra package (to ensure hash includes latest commit date)
@@ -85,7 +99,9 @@ jobs:
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-deps-lock-updates') }}
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: Auto-updated deps lock files
+          commit_user_name: ${{ steps.app-token.outputs.app-slug }}[bot]
+          commit_user_email: ${{ steps.app-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>
+          commit_message: Auto-updated deps lock files [skip actions]
           file_pattern: '*requirements.txt *package-lock.json'
           disable_globbing: true
   pipeline-deploy-aws-infra:

--- a/.github/workflows/main-build-and-deploy.yml
+++ b/.github/workflows/main-build-and-deploy.yml
@@ -36,6 +36,7 @@ jobs:
           ref: ${{ github.base_ref }}
           fetch-depth: 0
       - name: Download updated dependencies lock files bundle
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-deps-lock-updates') }}
         uses: dawidd6/action-download-artifact@v6
         with:
           name: deps_lock_files_bundle
@@ -47,11 +48,13 @@ jobs:
           if_no_artifact_found: fail
           skip_unpack: true
       - name: Unpack the bundle
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-deps-lock-updates') }}
         run: |
           tar -xzv -f deps-lock-files.tar.gz
       # Independent shared_aws_infra lock files commit required to pin hash representing the package
       # to be included in depending aws_infra components' lock files.
       - name: commit shared_aws_infra dependency lock file changes
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-deps-lock-updates') }}
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: Auto-updated pavi_shared_aws_infra deps lock files
@@ -73,11 +76,13 @@ jobs:
           name: shared_aws_infra_package
           path: shared_aws_infra/dist/pavi_shared_aws_infra-0.0.0-py3-none-any.whl
       - name: Update pavi_shared_aws_infra dependencies
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-deps-lock-updates') }}
         run: |
           make -C api/aws_infra/ pip-tools update-deps-lock-shared-aws-infra-only update-test-deps-lock-shared-aws-infra-only
           make -C pipeline/aws_infra/ pip-tools update-deps-lock-shared-aws-infra-only update-test-deps-lock-shared-aws-infra-only
           make -C webui/aws_infra/ pip-tools update-deps-lock-shared-aws-infra-only update-test-deps-lock-shared-aws-infra-only
       - name: commit remaining dependency lock file changes
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-deps-lock-updates') }}
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: Auto-updated deps lock files

--- a/.github/workflows/main-build-and-deploy.yml
+++ b/.github/workflows/main-build-and-deploy.yml
@@ -5,8 +5,8 @@ on:
     branches:
       - main
 jobs:
-  on-merge-and-deploy:
-    name: Skip on unmerged or 'no-deploy' PRs
+  on-merge:
+    name: Skip on unmerged
     if: github.event.pull_request.merged == true && !contains(github.event.pull_request.labels.*.name, 'no-deploy')
     runs-on: ubuntu-22.04
     steps:
@@ -14,36 +14,78 @@ jobs:
       shell: bash
       run: |
         echo "PR merge detected and deployment wanted."
-  shared-aws-infra-package-build:
-    name: shared_aws_infra python package build
-    needs:
-      - on-merge-and-deploy
+  on-deploy:
+    name: Skip on 'no-deploy' PRs
+    needs: on-merge
+    if: github.event.pull_request.merged == true && !contains(github.event.pull_request.labels.*.name, 'no-deploy')
     runs-on: ubuntu-22.04
-    defaults:
-      run:
-        working-directory: ./shared_aws_infra
     steps:
-    - name: Check out repository code
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        sparse-checkout: |
-          shared_aws_infra/
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.12"
-    - name: Build package
+    - name: Confirm execution
+      shell: bash
       run: |
-        make build
-    - name: Upload package as artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: shared_aws_infra_package
-        path: shared_aws_infra/dist/pavi_shared_aws_infra-0.0.0-py3-none-any.whl
+        echo "PR merge detected and deployment wanted."
+  commit-deps-lock-updates:
+    runs-on: ubuntu-22.04
+    needs:
+      - on-merge
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.base_ref }}
+          fetch-depth: 0
+      - name: Download updated dependencies lock files bundle
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          name: deps_lock_files_bundle
+          pr: ${{ github.event.pull_request.number }}
+          workflow: PR-validation.yml
+          workflow_conclusion: success
+          workflow_search: false
+          allow_forks: false
+          if_no_artifact_found: fail
+          skip_unpack: true
+      - name: Unpack the bundle
+        run: |
+          tar -xzv -f deps-lock-files.tar.gz
+      # Independent shared_aws_infra lock files commit required to pin hash representing the package
+      # to be included in depending aws_infra components' lock files.
+      - name: commit shared_aws_infra dependency lock file changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: Auto-updated pavi_shared_aws_infra deps lock files
+          file_pattern: 'shared_aws_infra/requirements.txt shared_aws_infra/tests/requirements.txt'
+          disable_globbing: true
+      # Build pavi_shared_aws_infra package (to ensure hash includes latest commit date)
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build and install the pavi_shared_aws_infra package
+        working-directory: ./shared_aws_infra
+        run: |
+          make clean build install
+      - name: Upload package as artifact
+        id: shared-aws-infra-package
+        uses: actions/upload-artifact@v4
+        with:
+          name: shared_aws_infra_package
+          path: shared_aws_infra/dist/pavi_shared_aws_infra-0.0.0-py3-none-any.whl
+      - name: Update pavi_shared_aws_infra dependencies
+        run: |
+          make -C api/aws_infra/ pip-tools update-deps-lock-shared-aws-infra-only update-test-deps-lock-shared-aws-infra-only
+          make -C pipeline/aws_infra/ pip-tools update-deps-lock-shared-aws-infra-only update-test-deps-lock-shared-aws-infra-only
+          make -C webui/aws_infra/ pip-tools update-deps-lock-shared-aws-infra-only update-test-deps-lock-shared-aws-infra-only
+      - name: commit remaining dependency lock file changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: Auto-updated deps lock files
+          file_pattern: '*requirements.txt *package-lock.json'
+          disable_globbing: true
   pipeline-deploy-aws-infra:
     name: Deploy/update AWS infrastructure for pipeline
-    needs: [shared-aws-infra-package-build]
+    needs: [commit-deps-lock-updates]
     permissions:
       id-token: write # This is required for requesting the JWT for gaining permissions to assume the IAM role to perform AWS actions
     runs-on: ubuntu-22.04
@@ -53,6 +95,8 @@ jobs:
     steps:
     - name: Check out repository code
       uses: actions/checkout@v4
+      with:
+        ref: ${{ github.base_ref }}
     - name: Setup node.js (CDK requirement)
       uses: actions/setup-node@v4
       with:
@@ -82,7 +126,7 @@ jobs:
       run: make deploy ADD_CDK_ARGS="--require-approval never"
   api-deploy-image-repo:
     name: Deploy/update container image repository stack for API
-    needs: [shared-aws-infra-package-build]
+    needs: [commit-deps-lock-updates]
     permissions:
       id-token: write # This is required for requesting the JWT for gaining permissions to assume the IAM role to perform AWS actions
     runs-on: ubuntu-22.04
@@ -92,6 +136,8 @@ jobs:
     steps:
     - name: Check out repository code
       uses: actions/checkout@v4
+      with:
+        ref: ${{ github.base_ref }}
     - name: Setup node.js (CDK requirement)
       uses: actions/setup-node@v4
       with:
@@ -121,7 +167,7 @@ jobs:
       run: make deploy-image-stack ADD_CDK_ARGS="--require-approval never"
   webui-deploy-image-repo:
     name: Deploy/update container image repository stack for web UI
-    needs: [shared-aws-infra-package-build]
+    needs: [commit-deps-lock-updates]
     permissions:
       id-token: write # This is required for requesting the JWT for gaining permissions to assume the IAM role to perform AWS actions
     runs-on: ubuntu-22.04
@@ -131,6 +177,8 @@ jobs:
     steps:
     - name: Check out repository code
       uses: actions/checkout@v4
+      with:
+        ref: ${{ github.base_ref }}
     - name: Setup node.js (CDK requirement)
       uses: actions/setup-node@v4
       with:
@@ -159,7 +207,7 @@ jobs:
     - name: Deploy CDK stack
       run: make deploy-image-stack ADD_CDK_ARGS="--require-approval never"
   pipeline-seq-retrieval-build-and-push-docker-image:
-    needs: [on-merge-and-deploy, pipeline-deploy-aws-infra]
+    needs: [on-deploy, pipeline-deploy-aws-infra, commit-deps-lock-updates]
     permissions:
       id-token: write # This is required for requesting the JWT for gaining permissions to assume the IAM role to perform AWS actions
     runs-on: ubuntu-22.04
@@ -167,6 +215,7 @@ jobs:
     - name: Check out repository code
       uses: actions/checkout@v4
       with:
+        ref: ${{ github.base_ref }}
         fetch-depth: 0
         sparse-checkout: |
           pipeline/seq_retrieval/
@@ -197,7 +246,7 @@ jobs:
           ${{ steps.login-ecr.outputs.registry }}/agr_pavi/pipeline_seq_retrieval:${{ github.event.pull_request.base.ref }}
         platforms: linux/amd64
   pipeline-alignment-build-and-push-docker-image:
-    needs: [on-merge-and-deploy, pipeline-deploy-aws-infra]
+    needs: [on-deploy, pipeline-deploy-aws-infra, commit-deps-lock-updates]
     permissions:
       id-token: write # This is required for requesting the JWT for gaining permissions to assume the IAM role to perform AWS actions
     runs-on: ubuntu-22.04
@@ -205,6 +254,7 @@ jobs:
     - name: Check out repository code
       uses: actions/checkout@v4
       with:
+        ref: ${{ github.base_ref }}
         fetch-depth: 0
         sparse-checkout: |
           pipeline/alignment/
@@ -235,7 +285,7 @@ jobs:
           ${{ steps.login-ecr.outputs.registry }}/agr_pavi/pipeline_alignment:${{ github.event.pull_request.base.ref }}
         platforms: linux/amd64
   api-build-and-push-docker-image:
-    needs: [on-merge-and-deploy, api-deploy-image-repo]
+    needs: [on-deploy, api-deploy-image-repo, commit-deps-lock-updates]
     permissions:
       id-token: write # This is required for requesting the JWT for gaining permissions to assume the IAM role to perform AWS actions
     runs-on: ubuntu-22.04
@@ -243,6 +293,7 @@ jobs:
     - name: Check out repository code
       uses: actions/checkout@v4
       with:
+        ref: ${{ github.base_ref }}
         fetch-depth: 0
     - name: Store release tag in env
       shell: bash
@@ -272,7 +323,7 @@ jobs:
           ${{ steps.login-ecr.outputs.registry }}/agr_pavi/api:${{ github.event.pull_request.base.ref }}
         platforms: linux/amd64
   webui-build-and-push-docker-image:
-    needs: [on-merge-and-deploy, webui-deploy-image-repo]
+    needs: [on-deploy, webui-deploy-image-repo, commit-deps-lock-updates]
     permissions:
       id-token: write # This is required for requesting the JWT for gaining permissions to assume the IAM role to perform AWS actions
     runs-on: ubuntu-22.04
@@ -280,6 +331,7 @@ jobs:
     - name: Check out repository code
       uses: actions/checkout@v4
       with:
+        ref: ${{ github.base_ref }}
         fetch-depth: 0
     - name: Store release tag in env
       shell: bash
@@ -310,8 +362,8 @@ jobs:
   api-deploy-application:
     name: Deploy application (version) for API
     needs:
-      - on-merge-and-deploy
-      - shared-aws-infra-package-build
+      - on-deploy
+      - commit-deps-lock-updates
       - api-build-and-push-docker-image
       - pipeline-alignment-build-and-push-docker-image
       - pipeline-seq-retrieval-build-and-push-docker-image
@@ -325,6 +377,7 @@ jobs:
     - name: Check out repository code
       uses: actions/checkout@v4
       with:
+        ref: ${{ github.base_ref }}
         fetch-depth: 0
     - name: Store release tag in env
       shell: bash
@@ -363,8 +416,8 @@ jobs:
   webui-deploy-application:
     name: Deploy application (version) for web UI
     needs:
-      - on-merge-and-deploy
-      - shared-aws-infra-package-build
+      - on-deploy
+      - commit-deps-lock-updates
       - webui-build-and-push-docker-image
       - api-deploy-application
     permissions:
@@ -377,6 +430,7 @@ jobs:
     - name: Check out repository code
       uses: actions/checkout@v4
       with:
+        ref: ${{ github.base_ref }}
         fetch-depth: 0
     - name: Store release tag in env
       shell: bash

--- a/api/aws_infra/requirements.txt
+++ b/api/aws_infra/requirements.txt
@@ -73,7 +73,7 @@ jsii==1.101.0 \
     #   aws-cdk-lib
     #   constructs
 pavi-shared-aws-infra @ file:///tmp/pavi_shared_aws_infra-0.0.0-py3-none-any.whl \
-    --hash=sha256:c539c9a00077e196afa9b47121944873da8e4920c373c77ddfd0ac8e06e199ba
+    --hash=sha256:97056f9bbe0561ac209b4fc0e6d6112ec00c980a9c7490ce16292e35637b81b0
     # via api-aws_infra (pyproject.toml)
 publication==0.0.3 \
     --hash=sha256:0248885351febc11d8a1098d5c8e3ab2dabcf3e8c0c96db1e17ecd12b53afbe6 \

--- a/api/aws_infra/tests/requirements.txt
+++ b/api/aws_infra/tests/requirements.txt
@@ -122,7 +122,7 @@ packaging==24.1 \
     --hash=sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124
     # via pytest
 pavi-shared-aws-infra @ file:///tmp/pavi_shared_aws_infra-0.0.0-py3-none-any.whl \
-    --hash=sha256:c539c9a00077e196afa9b47121944873da8e4920c373c77ddfd0ac8e06e199ba
+    --hash=sha256:97056f9bbe0561ac209b4fc0e6d6112ec00c980a9c7490ce16292e35637b81b0
     # via api-aws_infra (pyproject.toml)
 pluggy==1.5.0 \
     --hash=sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1 \

--- a/ci-scripts/create-git-diff-markdown.sh
+++ b/ci-scripts/create-git-diff-markdown.sh
@@ -14,4 +14,3 @@ echo '</details>' >> ${OUTFILE}
 echo '' >> ${OUTFILE}
 
 echo ${OUTFILE}
-cat ${OUTFILE}

--- a/ci-scripts/create-git-diff-markdown.sh
+++ b/ci-scripts/create-git-diff-markdown.sh
@@ -4,13 +4,13 @@ OUTDIR=$2
 OUTFILE=${OUTDIR}/${FILEPATH}.md
 
 install -D /dev/null ${OUTFILE}
-echo '<details>' > ${OUTFILE}
-echo '<summary>'${FILEPATH}'</summary>' > ${OUTFILE}
-echo '' > ${OUTFILE}
-echo '```diff' > ${OUTFILE}
-git diff -- ${FILEPATH} > ${OUTDIR}/${FILEPATH}.md
-echo '```diff' > ${OUTFILE}
-echo '</details>' > ${OUTFILE}
+echo '<details>' >> ${OUTFILE}
+echo '<summary>'${FILEPATH}'</summary>' >> ${OUTFILE}
+echo '' >> ${OUTFILE}
+echo '```diff' >> ${OUTFILE}
+git diff -- ${FILEPATH} >> ${OUTDIR}/${FILEPATH}.md
+echo '```diff' >> ${OUTFILE}
+echo '</details>' >> ${OUTFILE}
 
 echo ${OUTFILE}
 cat ${OUTFILE}

--- a/ci-scripts/create-git-diff-markdown.sh
+++ b/ci-scripts/create-git-diff-markdown.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+FILEPATH=$1
+OUTDIR=$2
+OUTFILE=${OUTDIR}/${FILEPATH}.md
+
+install -D /dev/null ${OUTFILE}
+echo '<details>' > ${OUTFILE}
+echo '<summary>'${FILEPATH}'</summary>' > ${OUTFILE}
+echo '' > ${OUTFILE}
+echo '```diff' > ${OUTFILE}
+git diff -- ${FILEPATH} > ${OUTDIR}/${FILEPATH}.md
+echo '```diff' > ${OUTFILE}
+echo '</details>' > ${OUTFILE}
+
+echo ${OUTFILE}

--- a/ci-scripts/create-git-diff-markdown.sh
+++ b/ci-scripts/create-git-diff-markdown.sh
@@ -13,3 +13,4 @@ echo '```diff' > ${OUTFILE}
 echo '</details>' > ${OUTFILE}
 
 echo ${OUTFILE}
+cat ${OUTFILE}

--- a/ci-scripts/create-git-diff-markdown.sh
+++ b/ci-scripts/create-git-diff-markdown.sh
@@ -11,6 +11,7 @@ echo '```diff' >> ${OUTFILE}
 git diff -- ${FILEPATH} >> ${OUTDIR}/${FILEPATH}.md
 echo '```diff' >> ${OUTFILE}
 echo '</details>' >> ${OUTFILE}
+echo '' >> ${OUTFILE}
 
 echo ${OUTFILE}
 cat ${OUTFILE}

--- a/ci-scripts/create-git-diff-markdown.sh
+++ b/ci-scripts/create-git-diff-markdown.sh
@@ -9,7 +9,7 @@ echo '<summary>'${FILEPATH}'</summary>' >> ${OUTFILE}
 echo '' >> ${OUTFILE}
 echo '```diff' >> ${OUTFILE}
 git diff -- ${FILEPATH} >> ${OUTDIR}/${FILEPATH}.md
-echo '```diff' >> ${OUTFILE}
+echo '```' >> ${OUTFILE}
 echo '</details>' >> ${OUTFILE}
 echo '' >> ${OUTFILE}
 

--- a/pipeline/aws_infra/requirements.txt
+++ b/pipeline/aws_infra/requirements.txt
@@ -73,7 +73,7 @@ jsii==1.101.0 \
     #   aws-cdk-lib
     #   constructs
 pavi-shared-aws-infra @ file:///tmp/pavi_shared_aws_infra-0.0.0-py3-none-any.whl \
-    --hash=sha256:c539c9a00077e196afa9b47121944873da8e4920c373c77ddfd0ac8e06e199ba
+    --hash=sha256:97056f9bbe0561ac209b4fc0e6d6112ec00c980a9c7490ce16292e35637b81b0
     # via pipeline-aws_infra (pyproject.toml)
 publication==0.0.3 \
     --hash=sha256:0248885351febc11d8a1098d5c8e3ab2dabcf3e8c0c96db1e17ecd12b53afbe6 \

--- a/pipeline/aws_infra/tests/requirements.txt
+++ b/pipeline/aws_infra/tests/requirements.txt
@@ -122,7 +122,7 @@ packaging==24.1 \
     --hash=sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124
     # via pytest
 pavi-shared-aws-infra @ file:///tmp/pavi_shared_aws_infra-0.0.0-py3-none-any.whl \
-    --hash=sha256:c539c9a00077e196afa9b47121944873da8e4920c373c77ddfd0ac8e06e199ba
+    --hash=sha256:97056f9bbe0561ac209b4fc0e6d6112ec00c980a9c7490ce16292e35637b81b0
     # via pipeline-aws_infra (pyproject.toml)
 pluggy==1.5.0 \
     --hash=sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1 \

--- a/shared_aws_infra/Makefile
+++ b/shared_aws_infra/Makefile
@@ -16,6 +16,7 @@ build:
 	 export SOURCE_DATE_EPOCH=$$(git show --no-patch --format=%ct $$REF) && \
 	 echo "SOURCE_DATE_EPOCH: $$SOURCE_DATE_EPOCH" && \
 	 python3.12 -m build
+	 pip hash dist/pavi_shared_aws_infra-0.0.0-py3-none-any.whl
 
 install:
 	cp dist/pavi_shared_aws_infra-0.0.0-py3-none-any.whl /tmp/

--- a/shared_aws_infra/Makefile
+++ b/shared_aws_infra/Makefile
@@ -11,7 +11,7 @@ build:
 # Setting SOURCE_DATE_EPOCH to commit date,
 # so that build produces whl with reproducable hash given same source-code,
 # resulting in reproducable builds that don't result in hash mismatches on rebuild
-	REF=$$(git log -n 1 --format=%H ./) && \
+	REF=$$(git log -n 1 --format=%H ./pavi_shared_aws_infra) && \
 	 echo "REF: $$REF" && \
 	 export SOURCE_DATE_EPOCH=$$(git show --no-patch --format=%ct $$REF) && \
 	 echo "SOURCE_DATE_EPOCH: $$SOURCE_DATE_EPOCH" && \

--- a/shared_aws_infra/Makefile
+++ b/shared_aws_infra/Makefile
@@ -77,6 +77,12 @@ install-deps: requirements.txt
 install-test-deps: tests/requirements.txt
 	pip install -r tests/requirements.txt
 
+install-deps-update-dev: requirements.txt
+	pip install -U -r requirements.txt
+
+install-test-deps-update-dev: tests/requirements.txt
+	pip install -U -r tests/requirements.txt
+
 run-unit-tests: check-node install-test-deps
 	python -m pytest
 

--- a/webui/aws_infra/requirements.txt
+++ b/webui/aws_infra/requirements.txt
@@ -73,7 +73,7 @@ jsii==1.101.0 \
     #   aws-cdk-lib
     #   constructs
 pavi-shared-aws-infra @ file:///tmp/pavi_shared_aws_infra-0.0.0-py3-none-any.whl \
-    --hash=sha256:c539c9a00077e196afa9b47121944873da8e4920c373c77ddfd0ac8e06e199ba
+    --hash=sha256:97056f9bbe0561ac209b4fc0e6d6112ec00c980a9c7490ce16292e35637b81b0
     # via webui-aws_infra (pyproject.toml)
 publication==0.0.3 \
     --hash=sha256:0248885351febc11d8a1098d5c8e3ab2dabcf3e8c0c96db1e17ecd12b53afbe6 \

--- a/webui/aws_infra/tests/requirements.txt
+++ b/webui/aws_infra/tests/requirements.txt
@@ -122,7 +122,7 @@ packaging==24.1 \
     --hash=sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124
     # via pytest
 pavi-shared-aws-infra @ file:///tmp/pavi_shared_aws_infra-0.0.0-py3-none-any.whl \
-    --hash=sha256:c539c9a00077e196afa9b47121944873da8e4920c373c77ddfd0ac8e06e199ba
+    --hash=sha256:97056f9bbe0561ac209b4fc0e6d6112ec00c980a9c7490ce16292e35637b81b0
     # via webui-aws_infra (pyproject.toml)
 pluggy==1.5.0 \
     --hash=sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1 \


### PR DESCRIPTION
Stage proposed updates during PR validation as comment in open PR, commit changes after PR approval and merge. This prevents need to run repeated PR validation runs as each commit made to an open PR requires a new PR validation run.