### PR TITLE
Fix PR-validation cancellation on closed PRs.

### DIFF
--- a/.github/workflows/PR-validation.yml
+++ b/.github/workflows/PR-validation.yml
@@ -11,16 +11,24 @@ jobs:
   skip-validation-on-closed:
     name: Skip PR-validations for closed PR (validation on closed PRs are irrelevant)
     if: github.event.pull_request.state == 'closed'
-    # This concurrency causes a deadlock between this job and the top level workflow,
-    # which effectively cancels the current workflow run.
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
     runs-on: ubuntu-22.04
     steps:
-    - name: Cancelling all PR validation runs for PR ${{ github.event.pull_request.number }}
-      run: |
-        echo "Done."
+    - name: Cancelling this PR validation run.
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const delay = ms => new Promise(res => setTimeout(res, ms));
+
+          github.rest.actions.cancelWorkflowRun({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            run_id: context.runId
+          });
+
+          while (true) {
+            core.info('Waiting for workflow to cancel ...');
+            await delay(5000);
+          }
   container-build-context:
     name: define container image build context variables
     runs-on: ubuntu-22.04

--- a/.github/workflows/PR-validation.yml
+++ b/.github/workflows/PR-validation.yml
@@ -11,6 +11,8 @@ jobs:
   skip-validation-on-closed:
     name: Skip PR-validations for closed PR (validation on closed PRs are irrelevant)
     if: github.event.pull_request.state == 'closed'
+    permissions:
+      actions: write
     runs-on: ubuntu-22.04
     steps:
     - name: Cancelling this PR validation run.

--- a/.github/workflows/PR-validation.yml
+++ b/.github/workflows/PR-validation.yml
@@ -19,13 +19,16 @@ jobs:
       uses: actions/github-script@v6
       with:
         script: |
-          const delay = ms => new Promise(res => setTimeout(res, ms));
-
           github.rest.actions.cancelWorkflowRun({
             owner: context.repo.owner,
             repo: context.repo.repo,
             run_id: context.runId
           });
+    - name: Waiting for workflow to cancel
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const delay = ms => new Promise(res => setTimeout(res, ms));
 
           while (true) {
             core.info('Waiting for workflow to cancel ...');


### PR DESCRIPTION
GitHub seems to have changed its behavior on concurrency deadlocks, only failing the conflicting job now rather than cancelling the complete run.